### PR TITLE
HandleSQSSend allow for array body

### DIFF
--- a/example-spec.yaml
+++ b/example-spec.yaml
@@ -56,9 +56,11 @@ role: generate
 #   the starenv derefers, lambdafy adds the following derefers:
 #
 #   - lambdafy_sqs_send: This derefer will be replaced with a URL which when POSTed
-#     to will send a message to the SQS queue whose ARN is specified. The body
-#     of the POST will be sent as the SQS message body. If header
-#     'Lambdafy-SQS-Group-Id' is set, it will be used as Group ID for the
+#     to will send a message to the SQS queue whose ARN is specified. This accepts
+#     either a JSON array of messages or a single message. If an array, the body
+#     of the POST will be split into batches and sent as entries in SQS send message batch.
+#     Otherwise, if a single messsage, the body of the POST will be sent as the SQS message body.
+#     If header 'Lambdafy-SQS-Group-Id' is set, it will be used as Group ID for the
 #     message. A 2xx/3xx response is considered a success, otherwise a fail. See
 #     the example below for usage.
 #     Note: The necessary IAM role permissions to send SQS messages are added

--- a/proxy/sqs.go
+++ b/proxy/sqs.go
@@ -213,15 +213,18 @@ func handleSQSSend(w http.ResponseWriter, r *http.Request) {
 
 	var messages []string
 	if err := json.Unmarshal(body, &messages); err != nil {
+		log.Printf("Send message batch failure - Invalid JSON array: %v", err)
 		http.Error(w, "Invalid JSON array", http.StatusBadRequest)
 		return
 	}
 
 	if len(messages) == 0 {
+		log.Printf("Send message batch failure - Empty message array")
 		http.Error(w, "Empty message array", http.StatusBadRequest)
 		return
 	}
 	if len(messages) > maxSQSBatchSize {
+		log.Printf("Send message batch failure - Too many messages in batch, maximum is %d", maxSQSBatchSize)
 		http.Error(w, fmt.Sprintf("Too many messages in batch, maximum is %d", maxSQSBatchSize), http.StatusBadRequest)
 		return
 	}

--- a/proxy/sqs.go
+++ b/proxy/sqs.go
@@ -193,7 +193,7 @@ func handleSQSSend(w http.ResponseWriter, r *http.Request) {
 	sqsCl := sqs.NewFromConfig(c)
 
 	if len(body) > 0 && isBatchMessage {
-		var messages []json.RawMessage
+		var messages []string
 		if err := json.Unmarshal(body, &messages); err != nil {
 			http.Error(w, "Invalid JSON array", http.StatusBadRequest)
 			return
@@ -209,7 +209,7 @@ func handleSQSSend(w http.ResponseWriter, r *http.Request) {
 		for i, msg := range messages {
 			allEntries = append(allEntries, sqstypes.SendMessageBatchRequestEntry{
 				Id:             aws.String(fmt.Sprintf("msg-%d", i)),
-				MessageBody:    aws.String(string(msg)),
+				MessageBody:    aws.String(msg),
 				MessageGroupId: groupID,
 			})
 		}

--- a/proxy/sqs.go
+++ b/proxy/sqs.go
@@ -23,6 +23,8 @@ import (
 	sqstypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
 )
 
+const maxSQSBatchSize = 10 // SQS allows a maximum of 10 messages per batch
+
 var sqsARNPat = regexp.MustCompile(`^arn:aws:sqs:([^:]+):([^:]+):(.+)$`)
 
 // getSQSQueueURL returns the URL of the SQS queue given its ARN.
@@ -214,9 +216,8 @@ func handleSQSSend(w http.ResponseWriter, r *http.Request) {
 			})
 		}
 
-		// Send in batches of 10 (SQS limit)
-		for i := 0; i < len(allEntries); i += 10 {
-			end := i + 10
+		for i := 0; i < len(allEntries); i += maxSQSBatchSize {
+			end := i + maxSQSBatchSize
 			if end > len(allEntries) {
 				end = len(allEntries)
 			}

--- a/proxy/sqs.go
+++ b/proxy/sqs.go
@@ -208,7 +208,7 @@ func handleSQSSend(w http.ResponseWriter, r *http.Request) {
 		var allEntries []sqstypes.SendMessageBatchRequestEntry
 		for i, msg := range messages {
 			allEntries = append(allEntries, sqstypes.SendMessageBatchRequestEntry{
-				Id:             aws.String(fmt.Sprintf("msg-%d", i)),
+				Id:             aws.String(fmt.Sprintf("%d", i)),
 				MessageBody:    aws.String(msg),
 				MessageGroupId: groupID,
 			})


### PR DESCRIPTION
Allows for JSON array to be sent to the sqs send handler.

This is backwards compatible with single message send

You can put as many messages in a single request to the handler. It will split them into 10 or less batches for relaying to the SQS queue with SendMessageBatch